### PR TITLE
Integrate new command: /bitetimes

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ const guessIconUrl = (icon_id, hr=false) => {
     }
     // Now we can build the folder from the padded icon_id
     folder_id = icon_id[0] + icon_id[1] + icon_id[2] + '000'
-    return guess = 'https://xivapi.com/i/' + folder_id + '/' + icon_id + (hr?'_hr1':'') + '.png'
+    return 'https://xivapi.com/i/' + folder_id + '/' + icon_id + (hr?'_hr1':'') + '.png'
 }
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
@@ -191,7 +191,7 @@ client.on('interactionCreate', async interaction => {
         try {
             const windows = await fetch('https://ff14-fish-planner.herokuapp.com/windows?format=discord&fish=' + encodeURIComponent(fish)).then(response => response.json());
             embed.setColor('#1fa1e0')
-                .setThumbnail(guessIconUrl(windows.icon))
+                .setThumbnail(guessIconUrl(windows.icon, true))
                 .setFooter('Based on FFX|V Fish Tracker App by Carbuncle Plushy. Run time: ' + windows.runtime.substring(0, 5) + 'ms')
             if(null != windows.folklore) {
                 embed.setAuthor(

--- a/app.js
+++ b/app.js
@@ -39,7 +39,6 @@ client.on('interactionCreate', async interaction => {
 client.on('interactionCreate', async interaction => {
     if (!interaction.isSelectMenu()) return;
 
-    console.log(Object.keys(DATA.SPOTS))
     if (interaction.customId === 'region') {
         const row = new MessageActionRow()
             .addComponents(
@@ -48,7 +47,6 @@ client.on('interactionCreate', async interaction => {
                     .setPlaceholder('Select Zone')
                     // ZONES
                     .addOptions(Object.keys(DATA.SPOTS[interaction.values[0]]).map(key => { 
-                        console.log(key)
                         return {
                             label: key.replace(/(^\w{1})|(\s+\w{1})|(_+\w{1})/g, letter => letter.toUpperCase()),  // hopefully prettier
                             value: key}

--- a/app.js
+++ b/app.js
@@ -10,16 +10,16 @@ const DATA = require('./data.js')
 
 // helper function for determining icon url
 // via: https://xivapi.com/docs/Icons
-const guessIconUrl = (icon_id) => {
+const guessIconUrl = (icon_id, hr=false) => {
+    // ensure string
+    icon_id = icon_id.toString()
     // first we need to add padding to the icon_id
     if (icon_id.length < 6) {
         icon_id = icon_id.padStart(6, '0')
     }
-
     // Now we can build the folder from the padded icon_id
     folder_id = icon_id[0] + icon_id[1] + icon_id[2] + '000'
-
-    return 'https://xivapi.com/i/' + folder_id + '/' + icon_id + '_hr1.png'
+    return guess = 'https://xivapi.com/i/' + folder_id + '/' + icon_id + (hr?'_hr1':'') + '.png'
 }
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
@@ -178,9 +178,18 @@ client.on('interactionCreate', async interaction => {
         try {
             const windows = await fetch('https://ff14-fish-planner.herokuapp.com/windows?format=discord&fish=' + encodeURIComponent(fish)).then(response => response.json());
             embed.setColor('#1fa1e0')
-                .setAuthor('Upcoming windows for: ' + fish)
                 .setThumbnail(guessIconUrl(windows.icon))
                 .setFooter('Based on FFX|V Fish Tracker App by Carbuncle Plushy. Run time: ' + windows.runtime.substring(0, 5) + 'ms')
+            if(null != windows.folklore) {
+                embed.setAuthor(
+                        'Upcoming windows for: ' + fish,
+                        'https://xivapi.com/i/026000/026164.png',
+                        'https://ffxivteamcraft.com/search?type=Item&query=' + encodeURIComponent(windows.folklore))
+                     .setDescription(windows.folklore)
+            } else {
+                embed.setAuthor(
+                    'Upcoming windows for: ' + fish)
+            }
             const availabilities = windows.availability.slice(0, numWindows)
             let windowStrings
             if (compactMode) {

--- a/app.js
+++ b/app.js
@@ -1,22 +1,25 @@
-const { Client, Intents, MessageEmbed } = require('discord.js');
-//const { token } = require('./config.json');
+const { Client, Intents, MessageEmbed, MessageActionRow, MessageSelectMenu, MessageButton, MessageAttachment } = require('discord.js');
+const Canvas = require('canvas');
+
+// const { token } = require('./config.json');
 const token = process.env.TOKEN
 
 const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
+const DATA = require('./data.js')
 
 // helper function for determining icon url
 // via: https://xivapi.com/docs/Icons
 const guessIconUrl = (icon_id) => {
     // first we need to add padding to the icon_id
-    if(icon_id.length < 6) {
+    if (icon_id.length < 6) {
         icon_id = icon_id.padStart(6, '0')
-    } 
+    }
 
     // Now we can build the folder from the padded icon_id
     folder_id = icon_id[0] + icon_id[1] + icon_id[2] + '000'
 
-    return 'https://xivapi.com/i/' + folder_id +'/' + icon_id + '_hr1.png'
+    return 'https://xivapi.com/i/' + folder_id + '/' + icon_id + '_hr1.png'
 }
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
@@ -25,17 +28,138 @@ client.once('ready', () => {
 });
 
 client.on('interactionCreate', async interaction => {
+    if (!interaction.isButton()) return;
+
+    if (interaction.customId === 'cancel') {
+        await interaction.deferUpdate();
+        await interaction.editReply({ content: 'Cancelled.', components: [] });
+    }
+})
+
+client.on('interactionCreate', async interaction => {
+    if (!interaction.isSelectMenu()) return;
+
+    console.log(Object.keys(DATA.SPOTS))
+    if (interaction.customId === 'region') {
+        const row = new MessageActionRow()
+            .addComponents(
+                new MessageSelectMenu()
+                    .setCustomId('zone')
+                    .setPlaceholder('Select Zone')
+                    // ZONES
+                    .addOptions(Object.keys(DATA.SPOTS[interaction.values[0]]).map(key => { 
+                        console.log(key)
+                        return {
+                            label: key.replace(/(^\w{1})|(\s+\w{1})|(_+\w{1})/g, letter => letter.toUpperCase()),  // hopefully prettier
+                            value: key}
+                        })),
+            )
+
+        const buttonRow = new MessageActionRow()
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('cancel')
+                    .setLabel('Cancel')
+                    .setStyle('SECONDARY'),
+            )
+
+        await interaction.update({ content: 'Chart bite times for a fishing spot.  Please make a selection:', ephemeral: true, components: [row, buttonRow] });
+    }
+
+    if (interaction.customId === 'zone') {
+        const regionKey = Object.keys(DATA.SPOTS).find(searchKey => interaction.values[0] in DATA.SPOTS[searchKey] )
+        
+        const row = new MessageActionRow()
+            .addComponents(
+                new MessageSelectMenu()
+                    .setCustomId('spot')
+                    .setPlaceholder('Select Fishing Spot')
+                    // SPOTS
+                    .addOptions(DATA.SPOTS[regionKey][interaction.values[0]].map(spot => { 
+                        return {
+                            label: spot[0],
+                            value: (spot[0] + ';' + spot[1].toString())
+                        }})),
+
+            )
+
+        const buttonRow = new MessageActionRow()
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('cancel')
+                    .setLabel('Cancel')
+                    .setStyle('SECONDARY'),
+            )
+
+        await interaction.update({ content: 'Chart bite times for a fishing spot.  Please make a selection:', ephemeral: true, components: [row, buttonRow] });
+    }
+
+    // Final step
+    if (interaction.customId === 'spot') {
+        await interaction.deferUpdate();
+
+        const interactionValue = interaction.values[0].split(';')
+        const bitetimes = await fetch('https://ff14-fishing-plotter.herokuapp.com/bitetimes?spotId=' + interactionValue[1]).then(response => response.json());
+           
+
+        // via discordjs documentation
+        const canvas = Canvas.createCanvas(635,274);
+        const context = canvas.getContext('2d');
+        const background = await Canvas.loadImage(bitetimes.plot);
+
+        // This uses the canvas dimensions to stretch the image onto the entire canvas
+        context.drawImage(background, 0, 0, canvas.width, canvas.height);
+
+        // Use the helpful Attachment class structure to process the file for you
+       const attachment = new MessageAttachment(canvas.toBuffer(), 'buffered-image.png');
+
+       const bitetimesEmbed = new MessageEmbed()
+            .setColor('#1fa1e0')
+            .setAuthor('Bite times for fishing spot: ' + interactionValue[0])
+            .setImage('attachment://buffered-image.png')
+            .setFooter('Based on FFXIV Teamcraft by Miu#1568. Run time: ' + bitetimes.runtime)
+
+        await interaction.followUp({ components: [], embeds: [bitetimesEmbed], files: [attachment] });
+        await interaction.editReply({ content: 'Finished!', components: [] });
+    }
+});
+
+client.on('interactionCreate', async interaction => {
     if (!interaction.isCommand()) return;
 
     const { commandName } = interaction;
+
+    if (commandName === 'bitetimes') {
+        const row = new MessageActionRow()
+            .addComponents(
+                new MessageSelectMenu()
+                    .setCustomId('region')
+                    .setPlaceholder('Select Region')
+                    // REGION
+                    .addOptions(Object.keys(DATA.SPOTS).map(key => { 
+                        return {
+                            label: key.replace(/(^\w{1})|(\s+\w{1})|(_+\w{1})/g, letter => letter.toUpperCase()),  // hopefully prettier
+                            value: key}
+                        })),
+            )
+        const buttonRow = new MessageActionRow()
+            .addComponents(
+                new MessageButton()
+                    .setCustomId('cancel')
+                    .setLabel('Cancel')
+                    .setStyle('SECONDARY'),
+            )
+
+        await interaction.reply({ content: 'Chart bite times for a fishing spot.  Please make a selection:', ephemeral: true, components: [row, buttonRow] });
+    }
 
     if (commandName === 'windows') {
         await interaction.deferReply();
         const fish = interaction.options.getString('fish');
         const numWindows = Math.min(10, interaction.options.getInteger('number_of_windows') || 5)
-        const displayDowntime = interaction.options.getBoolean('display_downtime') === null? true: interaction.options.getBoolean('display_downtime')
-        const compactMode = interaction.options.getBoolean('compact_mode') === null? true: interaction.options.getBoolean('compact_mode') 
-        const displayDuration = interaction.options.getBoolean('display_duration') === null? false: interaction.options.getBoolean('display_duration')
+        const displayDowntime = interaction.options.getBoolean('display_downtime') === null ? true : interaction.options.getBoolean('display_downtime')
+        const compactMode = interaction.options.getBoolean('compact_mode') === null ? true : interaction.options.getBoolean('compact_mode')
+        const displayDuration = interaction.options.getBoolean('display_duration') === null ? false : interaction.options.getBoolean('display_duration')
 
 
         const embed = new MessageEmbed()
@@ -44,32 +168,32 @@ client.on('interactionCreate', async interaction => {
             embed.setColor('#1fa1e0')
                 .setAuthor('Upcoming windows for: ' + fish)
                 .setThumbnail(guessIconUrl(windows.icon))
-                .setFooter('Based on FFX|V Fish Tracker App by Carbuncle Plushy. Run time: ' + windows.runtime.substring(0, 5) + 'ms')            
-                const availabilities = windows.availability.slice(0, numWindows)
-                let windowStrings
-                if(compactMode) {
-                    windowStrings = availabilities.map(a => (a.start - Date.now() < 8.64e+7?`<t:${(a.start / 1000).toFixed(0)}:R>`:`<t:${(a.start / 1000).toFixed(0)}:d> <t:${(a.start / 1000).toFixed(0)}:t>`)+ `${displayDuration? ' ('+ a.duration + ')': ''}${displayDowntime? '; ' + a.downtime:''}`)
-                    embed.addField('Next Window Start'+(displayDuration?' (Duration)': '') + (displayDowntime?'; Downtime':''), windowStrings.join('\n'), true)
-                } else {
-                    windowStrings = availabilities.map(a => `<t:${(a.start / 1000).toFixed(0)}:${(a.start - Date.now() < 8.64e+7)?'R':'D'}>`)  //shows relative time under 24h
-                    embed.addField('Next Start', windowStrings.join('\n'), true)
-                    if(displayDuration) {
-                        embed.addField('Duration', availabilities.map(a => `${a.duration}`).join('\n'), true)
-                    }
-                    if(displayDowntime) {
-                        embed.addField('Downtime', availabilities.map(a => `${a.downtime || '\u200b'}`).join('\n'), true)
-                    }
-                    
+                .setFooter('Based on FFX|V Fish Tracker App by Carbuncle Plushy. Run time: ' + windows.runtime.substring(0, 5) + 'ms')
+            const availabilities = windows.availability.slice(0, numWindows)
+            let windowStrings
+            if (compactMode) {
+                windowStrings = availabilities.map(a => (a.start - Date.now() < 8.64e+7 ? `<t:${(a.start / 1000).toFixed(0)}:R>` : `<t:${(a.start / 1000).toFixed(0)}:d> <t:${(a.start / 1000).toFixed(0)}:t>`) + `${displayDuration ? ' (' + a.duration + ')' : ''}${displayDowntime ? '; ' + a.downtime : ''}`)
+                embed.addField('Next Window Start' + (displayDuration ? ' (Duration)' : '') + (displayDowntime ? '; Downtime' : ''), windowStrings.join('\n'), true)
+            } else {
+                windowStrings = availabilities.map(a => `<t:${(a.start / 1000).toFixed(0)}:${(a.start - Date.now() < 8.64e+7) ? 'R' : 'D'}>`)  //shows relative time under 24h
+                embed.addField('Next Start', windowStrings.join('\n'), true)
+                if (displayDuration) {
+                    embed.addField('Duration', availabilities.map(a => `${a.duration}`).join('\n'), true)
                 }
+                if (displayDowntime) {
+                    embed.addField('Downtime', availabilities.map(a => `${a.downtime || '\u200b'}`).join('\n'), true)
+                }
+
+            }
         } catch {
             embed.setColor('#1fa1e0')
-            .setTitle('Found no windows for: ' + fish)
-            .setThumbnail('https://xivapi.com/i/001000/001135.png')
-            .setFooter('If this message persists, it may be a problem with the backend.  Please @mention okuRaku#1417')
-            .setDescription('Please use exact spelling, with spaces and punctuation.  Click the above title link to search Teamcraft for your fish.')    
-            .setURL('https://ffxivteamcraft.com/search?type=Item&query=' + encodeURIComponent(fish))
+                .setTitle('Found no windows for: ' + fish)
+                .setThumbnail('https://xivapi.com/i/001000/001135.png')
+                .setFooter('If this message persists, it may be a problem with the backend.  Please @mention okuRaku#1417')
+                .setDescription('Please use exact spelling, with spaces and punctuation.  Click the above title link to search Teamcraft for your fish.')
+                .setURL('https://ffxivteamcraft.com/search?type=Item&query=' + encodeURIComponent(fish))
         }
-        
+
         interaction.editReply({
             embeds: [embed]
         });

--- a/data.js
+++ b/data.js
@@ -1,61 +1,364 @@
 module.exports = DATA = {
     SPOTS: {
+        "abalathias_spine":{
+            "the_sea_of_clouds":[
+                ["Voor Sian Siran",135],
+                ["The Eddies",136],
+                ["Cloudtop",137],
+                ["The Blue Window",138],
+                ["Mok Oogl Island",139],
+            ],
+            "azys_lla":[
+                ["Alpha Quadrant",140],
+                ["Aetherochemical Spill",141],
+                ["Hyperstellar Downconverter",142],
+                ["Delta Quadrant",143],
+                ["The Pappus Tree",144],
+                ["The Habisphere",145],
+                ["The Flagship",146],
+            ]
+        },
+        "coerthas":{
+            "coerthas_central_highlands":[
+                ["Coerthas River",26],
+                ["Witchdrop",27],
+                ["The Nail",28],
+                ["The Weeping Saint",29],
+                ["Dragonhead Latrines",30],
+                ["Daniffen Pass",31],
+                ["Exploratory Ice Hole",32],
+                ["Snowcloak",33],
+                ["Sea of Clouds",34],
+            ],
+            "coerthas_western_highlands":[
+                ["Riversmeet",109],
+                ["Greytail Falls",110],
+                ["Unfrozen Pond",111],
+                ["Clearpool",112],
+                ["Dragonspit",113],
+                ["South Banepool",114],
+                ["Ashpool",115],
+                ["West Banepool",116],
+            ]
+        },
+        "dravania":{
+            "the_dravanian_forelands":[
+                ["The Hundred Throes",117],
+                ["Whilom River",118],
+                ["The Smoldering Wastes",119],
+                ["The Iron Feast",120],
+                ["Mourn",121],
+                ["West Mourn",122],
+                ["Anyx Old",123],
+                ["Halo",124],
+            ],
+            "the_dravanian_hinterlands":[
+                ["Thaliak River",125],
+                ["Quickspill Delta",126],
+                ["Upper Thaliak River",127],
+                ["Middle Thaliak River",128],
+            ],
+            "the_churning_mists":[
+                ["Eil Tohm",129],
+                ["Greensward",130],
+                ["Weston Waters",131],
+                ["Landlord Colony",132],
+                ["Sohm Al Summit",133],
+                ["Tharl Oom Khash",134],
+            ],
+        },
+        "gyr_abania":{
+            "the_fringes":[
+                ["Timmon Beck",185],
+                ["Dimwold",186],
+                ["The Comet's Tail",187],
+                ["The Velodyna River",188],
+                ["Mirage Creek",189],
+            ],
+            "rhalgrs_reach":[
+                ["Upper Mirage Creek",182],
+                ["Rhalgr's Reach",183],
+                ["The Outer Fist",184],
+            ],
+            "the_peaks":[
+                ["Grymm & Enid",190],
+                ["The Slow Wash",191],
+                ["Heather Falls",192],
+                ["The Ephor",193],
+                ["The Bull's Bath",194],
+                ["The Arms of Meed",195],
+            ],
+            "the_lochs":[
+                ["Loch Seld",196],
+            ]
+        },
+        "hingashi":{
+            "kugane":[
+                ["Kugane Piers",157],
+            ],
+            "shirogane":[
+                ["Shirogane",197],
+                ["The Silver Canal",198]
+            ]
+        },
+        "la_noscea":{
+            "limsa_lominsa_upper_decks":[
+                ["Limsa Lominsa Upper Decks",36],
+            ],
+            "limsa_lominsa_lower_decks":[
+                ["Limsa Lominsa Lower Decks",35],
+            ],
+            "mist":[
+                ["Mist",104]
+            ],
+            "middle_la_noscea":[
+                ["Zephyr Drift",37],
+                ["Summerford",38],
+                ["Rogue River",39],
+                ["West Agelyss River",40],
+                ["Nym River",41],
+                ["Woad Whisper Canyon",42],
+            ],
+            "lower_la_noscea":[
+                ["The Mourning Widow",43],
+                ["Moraby Bay",44],
+                ["Cedarwood",45],
+                ["Moraby Drydocks",46],
+                ["Oschon's Torch",47],
+                ["The Salt Strand",48],
+                ["Candlekeep Quay",49],
+                ["Empty Heart",50],
+                ["Blind Iron Mines",97]
+            ],
+            "eastern_la_noscea":[
+                ["South Bloodshore",51],
+                ["Costa del Sol",52],
+                ["North Bloodshore",53],
+                ["Hidden Falls",54],
+                ["East Agelyss River",55],
+                ["Raincatcher Gully",56],
+                ["The Juggernaut",57],
+                ["Red Mantis Falls",58],
+                ["Rhotano Sea (Privateer Forecastle)",107],
+                ["Rhotano Sea (Privateer Sterncastle)",108],
+                ["North Isle of Endless Summer",156],
+            ],
+            "western_la_noscea":[
+                ["Swiftperch",59],
+                ["Skull Valley",60],
+                ["Halfstone",61],
+                ["Isles of Umbra Northshore",62],
+                ["Isles of Umbra Southshore",63],
+                ["The Brewer's Beacon",64],
+                ["The Ship Graveyard",65],
+                ["Sapsa Spawning Grounds",101],
+                ["Reaver Hide",102],
+            ],
+            "upper_la_noscea":[
+                ["Oakwood",66],
+                ["Fool Falls",67],
+                ["Northeast Bronze Lake",68],
+                ["Bronze Lake Shallows",98]
+            ],
+            "outer_la_noscea":[
+                ["The Long Climb",99],
+                ["Northwest Bronze Lake",155]
+            ]            
+        },
+        "mor_dhona":{
+            "mor_dhona":[
+                ["North Silvertear",22],
+                ["Rathefrost",23],
+                ["The Tangle",24],
+                ["The Deep Tangle",25],
+                ["Singing Shards",93],
+                ["The North Shards",94],
+            ]
+        },
+        "othard":{
+            "the_ruby_sea":[
+                ["The Ruby Price",158],
+                ["Hells' Lid",159],
+                ["The Isle of Bekko",160],
+                ["Shoal Rock",161],
+                ["Onokoro",162],
+                ["Isari",163],
+                ["The Isle of Zekki",164],
+            ],
+            "yanxia":[
+                ["The Heron's Nest",165],
+                ["The Heron's Way",166],
+                ["Namai",167],
+                ["Prism Lake",168],
+                ["Prism Canyon",169],
+                ["Doma Castle",170],
+                ["Mercantile Docks",171],
+                ["The One River (East)",172],
+                ["The One River (West)",173],
+                ["Plum Spring",174],
+            ],
+            "the_azim_steppe":[
+                ["Nem Khaal",175],
+                ["Hak Khaal",176],
+                ["Upper Yat Khaal",177],
+                ["Azim Khaat",178],
+                ["Tao Khaal",179],
+                ["Lower Yat Khaal",180],
+                ["Dotharl Khaa",181],
+            ]
+        },
+        "thanalan":{
+            "the_goblet":[
+                ["The Goblet",106]
+            ],
+            "western_thanalan":[
+                ["The Silver Bazaar",69],
+                ["Vesper Bay",70],
+                ["Crescent Cove",71],
+                ["Nophica's Wells",72],
+                ["The Footfalls",73],
+                ["Cape Westwind",74],
+                ["Parata's Peace",95],
+                ["Moondrip",103],
+            ],
+            "central_thanalan":[
+                ["Upper Soot Creek",75],
+                ["Lower Soot Creek",76],
+                ["The Unholy Heir",77],
+                ["The Clutch",96]
+            ],
+            "eastern_thanalan":[
+                ["North Drybone",78],
+                ["South Drybone",79],
+                ["Yugr'am River",80],
+                ["The Burning Wall",82]
+            ],
+            "southern_thanalan":[
+                ["Burnt Lizard Creek",83],
+                ["Zahar'ak",84],
+                ["Forgotten Springs",85],
+                ["Sagolii Desert",86],
+                ["Sagolii Dunes",87],
+            ],
+            "northern_thanalan":[
+                ["Ceruleum Field",88],
+                ["Bluefog",89],
+            ]
+        },
+        "the_black_shroud":{
+            "the_lavender_beds":[
+                ["The Lavender Beds",105]
+            ],
+            "new_gridania":[
+                ["Jadeite Flood",90],
+                ["Lower Black Tea Brook",91]
+            ],
+            "old_gridania":[
+                ["Whispering Gorge",81],
+                ["Upper Black Tea Brook",100],
+            ],
+            "central_shroud":[
+                ["The Vein",2],
+                ["The Mirror",3],
+                ["Everschade",4],
+                ["Hopeseed Pond",5],
+                ["Haukke Manor",92]
+            ],
+            "east_shroud":[
+                ["Sweetbloom Pier",6],
+                ["Verdant Drop",7],
+                ["Springripple Brook",8],
+                ["Sylphlands",9],
+                ["Sanctum of the Twelve",10],
+            ],
+            "south_shroud":[
+                ["Upper Hathoeva River",11],
+                ["Middle Hathoeva River",12],
+                ["Lower Hathoeva River",13],
+                ["East Hathoeva River",14],
+                ["Goblinblood",15],
+                ["Rootslake",16],
+                ["Urth's Gift",17],
+            ],
+            "north_shroud":[
+                ["Murmur Rills",18],
+                ["Fallgourd Float",19],
+                ["Proud Creek",20],
+                ["Lake Tahtotl",21],
+            ],
+        },   
         "norvrandt": {
             "the_crystarium": [
-                ['Crystarium Personal Suites', 123],
-                ['The Quadrivium', 123],
-                ['The Trivium', 123]
+                ["The Trivium",199],
+                ["The Quadrivium",200],
+                ["Crystarium Personal Suites",201]
             ],
             "eulmore": [
-                ['The Derelicts', 123]
+                ["The Derelicts",214]
             ],
             "lakeland": [
-                ['The Rift of Sighs', 202],
-                ['The Rusted Reservoir', 203],
-                ['The Source', 204],
-                ['Sullen', 205],
-                ['The Isle of Ken', 206]
+                ["The Rift of Sighs",202],
+                ["The Rusted Reservoir",203],
+                ["The Source",204],
+                ["Sullen",205],
+                ["The Isle of Ken",206]
             ],
             "kholusia": [
-                ['Upper Watts River', 123],
-                ['White Oil Falls', 123],
-                ['Lower Watts River', 123],
-                ['Sharptongue Drip', 123],
-                ['The Western Kholusian Coast', 123],
-                ['Seagazer Shoals', 123],
-                ['The Eastern Kholusian Coast', 123]
+                ["Upper Watts River",207],
+                ["White Oil Falls",208],
+                ["Lower Watts River",209],
+                ["Sharptongue Drip",210],
+                ["The Western Kholusian Coast",211],
+                ["Seagazer Shoals",212],
+                ["The Eastern Kholusian Coast",213]
             ],
             "amh_araeng": [
-                ['The River of Sand', 123],
-                ['The Hills of Amber', 123],
-                ['The Nabaath Severance', 123]
+                ["The River of Sand",215],
+                ["The Hills of Amber",216],
+                ["The Nabaath Severance",217]
             ],
             "il_mheg": [
-                ['Handmirror Lake', 123],
-                ['Longmirror Lake', 123],
-                ['The Haughty One', 123],
-                ['The Jealous One', 123],
-                ['Father Collard\'s Failings', 123],
-                ['The Spoiled One', 123],
-                ['Saint Fathric\'s Temple', 123]
+                ["Handmirror Lake",218],
+                ["Longmirror Lake",219],
+                ["The Haughty One",220],
+                ["The Jealous One",221],
+                ["Father Collard's Failings",222],
+                ["The Spoiled One",223],
+                ["Saint Fathric's Temple",224],
             ],
             "the_raktika_greatwood": [
-                ['Lake Tusi Mek\'ta', 123],
-                ['The Red Chalice', 123],
-                ['The Lozatl', 123],
-                ['South Mjrl\'s Regret', 123],
-                ['Woven Oath', 123],
-                ['Mjrl\'s Tears', 123]
+                ["Lake Tusi Mek'ta",225],
+                ["The Red Chalice",226],
+                ["The Lozatl",227],
+                ["South Mjrl's Regret",228],
+                ["Woven Oath",229],
+                ["Mjrl's Tears",245]
             ],
             "the_tempest": [
-                ['The Flounders\' Floor', 123],
-                ['Where the Dry Return', 123],
-                ['Northwest Caliban Gorge', 123],
-                ['West Caliban Gap', 123],
-                ['East Caliban Gap', 123],
-                ['Purpure', 123],
-                ['The Norvrandt Slope', 123]
+                ["The Flounders' Floor",230],
+                ["Where the Dry Return",231],
+                ["Northwest Caliban Gorge",232],
+                ["West Caliban Gap",233],
+                ["East Caliban Gap",234],
+                ["Purpure",235],
+                ["The Norvrandt Slope",236]
             ]
-        }
+        },
+        "the_endeavor": [
+                ["Outer Galadion Bay",237],
+                ["Galadion Spectral Current",238],
+                ["The Southern Strait of Merlthor",239],
+                ["Southern Merlthor Spectral Current",240],
+                ["The Northern Straight of Merlthor",243],
+                ["Northern Merlthor Spectral Current",244],
+                ["Open Rhotano Sea",241],
+                ["Rhotano Spectral Current",242],
+                ["Cieldalaes Margin",246],
+                ["Cieldalaes Spectral Current",247],
+                ["Open Bloodbrine Sea",248],
+                ["Bloodbrine Spectral Current",249],
+                ["Outer Rothlyt Sound",250],
+                ["Rothlyt Spectral Current",251]
+        ]
     }
 }

--- a/data.js
+++ b/data.js
@@ -1,0 +1,61 @@
+module.exports = DATA = {
+    SPOTS: {
+        "norvrandt": {
+            "the_crystarium": [
+                ['Crystarium Personal Suites', 123],
+                ['The Quadrivium', 123],
+                ['The Trivium', 123]
+            ],
+            "eulmore": [
+                ['The Derelicts', 123]
+            ],
+            "lakeland": [
+                ['The Rift of Sighs', 202],
+                ['The Rusted Reservoir', 203],
+                ['The Source', 204],
+                ['Sullen', 205],
+                ['The Isle of Ken', 206]
+            ],
+            "kholusia": [
+                ['Upper Watts River', 123],
+                ['White Oil Falls', 123],
+                ['Lower Watts River', 123],
+                ['Sharptongue Drip', 123],
+                ['The Western Kholusian Coast', 123],
+                ['Seagazer Shoals', 123],
+                ['The Eastern Kholusian Coast', 123]
+            ],
+            "amh_araeng": [
+                ['The River of Sand', 123],
+                ['The Hills of Amber', 123],
+                ['The Nabaath Severance', 123]
+            ],
+            "il_mheg": [
+                ['Handmirror Lake', 123],
+                ['Longmirror Lake', 123],
+                ['The Haughty One', 123],
+                ['The Jealous One', 123],
+                ['Father Collard\'s Failings', 123],
+                ['The Spoiled One', 123],
+                ['Saint Fathric\'s Temple', 123]
+            ],
+            "the_raktika_greatwood": [
+                ['Lake Tusi Mek\'ta', 123],
+                ['The Red Chalice', 123],
+                ['The Lozatl', 123],
+                ['South Mjrl\'s Regret', 123],
+                ['Woven Oath', 123],
+                ['Mjrl\'s Tears', 123]
+            ],
+            "the_tempest": [
+                ['The Flounders\' Floor', 123],
+                ['Where the Dry Return', 123],
+                ['Northwest Caliban Gorge', 123],
+                ['West Caliban Gap', 123],
+                ['East Caliban Gap', 123],
+                ['Purpure', 123],
+                ['The Norvrandt Slope', 123]
+            ]
+        }
+    }
+}

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -41,7 +41,7 @@ const commands = [
         .addBooleanOption(option => option.setName('display_downtime').setRequired(false).setDescription('Display downtime between windows, varies due to weather randomness.  Default true.'))
         .addBooleanOption(option => option.setName('compact_mode').setRequired(false).setDescription('Compact view more suitable for mobile.  Default true.')),
     new SlashCommandBuilder().setName('bitetimes')
-        .setDescription('Bite timings for a spot.  Based on FFXIV Teamcraft')
+        .setDescription('Bite timings for a fishing spot.  Run without parameters (a menu will be presented).  Based on FFXIV Teamcraft')
 ]
     .map(command => command.toJSON());
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -3,6 +3,34 @@ const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { clientId, guildId, token } = require('./config.json');
 
+
+
+///////////
+// Turns out this was better to implement with select menus / components, but it was a lot of work so I'm holding here temporarily
+///////////
+// const bitetimesBuilder = new SlashCommandBuilder().setName('bitetimes')
+//             .setDescription(
+//                'Bite timings for a spot.  Based on FFXIV Teamcraft')
+// ['norvrandt', 'black_shroud'].forEach(region => {
+//     bitetimesBuilder.addSubcommandGroup(subcommandgroup => {
+//         subcommandgroup.setName(region).setDescription('Bite timings for a spot.  Based on FFXIV Teamcraft');
+//         ['the_crystarium', 'eulmore', 'lakeland', 'kholusia', 'amh_araeng', 'il_mheg', 'the_raktika_greatwood', 'the_tempest']
+//             .forEach(zone => {
+//                 subcommandgroup.addSubcommand(subcommand => subcommand.setName(zone).setDescription('Bite timings for a spot.  Based on FFXIV Teamcraft').addStringOption(option =>
+//                     option.setName('spot').setDescription(region).setRequired(true).addChoices(
+//                         [
+//                             ['The Rift of Sighs', '111'],
+//                             ['The Rusted Reservoir', 'val2'],
+//                             ['The Source', 'val2'],
+//                             ['Sullen', 'val2'],
+//                             ['The Isle of Ken', 'val2']
+//                         ])))
+//             })
+//         return subcommandgroup;
+//     })
+// })
+
+
 const commands = [
     new SlashCommandBuilder().setName('windows')
         .setDescription(
@@ -11,8 +39,9 @@ const commands = [
         .addIntegerOption(option => option.setName('number_of_windows').setRequired(false).setDescription('How many upcoming windows to show.  Minimum 1, maximum 10.  Default 5.'))
         .addBooleanOption(option => option.setName('display_duration').setRequired(false).setDescription('Display window durations, useful on fish where it can vary.  Default false.'))
         .addBooleanOption(option => option.setName('display_downtime').setRequired(false).setDescription('Display downtime between windows, varies due to weather randomness.  Default true.'))
-        .addBooleanOption(option => option.setName('compact_mode').setRequired(false).setDescription('Compact view more suitable for mobile.  Default true.'))
-
+        .addBooleanOption(option => option.setName('compact_mode').setRequired(false).setDescription('Compact view more suitable for mobile.  Default true.')),
+    new SlashCommandBuilder().setName('bitetimes')
+        .setDescription('Bite timings for a spot.  Based on FFXIV Teamcraft')
 ]
     .map(command => command.toJSON());
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -41,7 +41,7 @@ const commands = [
         .addBooleanOption(option => option.setName('display_downtime').setRequired(false).setDescription('Display downtime between windows, varies due to weather randomness.  Default true.'))
         .addBooleanOption(option => option.setName('compact_mode').setRequired(false).setDescription('Compact view more suitable for mobile.  Default true.')),
     new SlashCommandBuilder().setName('bitetimes')
-        .setDescription('Bite timings for a fishing spot.  Run without parameters (a menu will be presented).  Based on FFXIV Teamcraft')
+        .setDescription('Bite timings for a spot.  Run without parameters (a menu will appear).  Based on FFXIV Teamcraft')
 ]
     .map(command => command.toJSON());
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@discordjs/builders": "^0.6.0",
     "@discordjs/rest": "^0.1.0-canary.0",
+    "canvas": "^2.8.0",
     "discord-api-types": "^0.23.1",
     "discord.js": "^13.1.0",
     "node-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,21 @@
     node-fetch "^2.6.1"
     tslib "^2.3.0"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@sapphire/async-queue@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.4.tgz#ae431310917a8880961cebe8e59df6ffa40f2957"
@@ -84,6 +99,11 @@
   dependencies:
     "@types/node" "*"
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -91,15 +111,77 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+are-we-there-yet@~1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+canvas@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.8.0.tgz#f99ca7f25e6e26686661ffa4fec1239bbef74461"
+  integrity sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    nan "^2.14.0"
+    simple-get "^3.0.3"
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -108,15 +190,54 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
 data-uri-to-buffer@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
+debug@4:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 discord-api-types@^0.18.1:
   version "0.18.1"
@@ -175,15 +296,110 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
+glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+  dependencies:
+    number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
+make-dir@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
 
 mime-db@1.49.0:
   version "1.49.0"
@@ -196,6 +412,48 @@ mime-types@^2.1.12:
   integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
   dependencies:
     mime-db "1.49.0"
+
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minipass@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
+  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nan@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 node-fetch@^2.6.1:
   version "2.6.5"
@@ -212,6 +470,40 @@ node-fetch@^3.0.0:
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^3.1.2"
 
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
+npmlog@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+once@^1.3.0, once@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
 ow@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/ow/-/ow-0.27.0.tgz#d44da088e8184fa11de64b5813206f9f86ab68d0"
@@ -223,6 +515,127 @@ ow@^0.27.0:
     lodash.isequal "^4.5.0"
     type-fest "^1.2.1"
     vali-date "^1.0.0"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+readable-stream@^2.0.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+semver@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.4:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+set-blocking@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+signal-exit@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
+  integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
+  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
+
+tar@^6.1.0:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -243,6 +656,11 @@ type-fest@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 vali-date@^1.0.0:
   version "1.0.0"
@@ -267,7 +685,24 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+wide-align@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  dependencies:
+    string-width "^1.0.2 || 2"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
 ws@^7.5.1:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Leverages a new backend, ff14-fishing-plotter (publishing Soon™), which retrieves data from FFXIV Teamcraft and returns a chart.

Also sneaking in:  Add folklore note to fish that need it in `/windows`